### PR TITLE
Removed @Autowired(s) from JwtAuthenticationFilter

### DIFF
--- a/src/main/java/com/pokemonreview/api/security/JWTAuthenticationFilter.java
+++ b/src/main/java/com/pokemonreview/api/security/JWTAuthenticationFilter.java
@@ -16,11 +16,13 @@ import java.io.IOException;
 
 public class JWTAuthenticationFilter extends OncePerRequestFilter {
 
-    @Autowired
     private JWTGenerator tokenGenerator;
-    @Autowired
     private CustomUserDetailsService customUserDetailsService;
 
+    public JWTAuthenticationFilter(JWTGenerator tokenGenerator, CustomUserDetailsService customUserDetailsService) {
+        this.tokenGenerator = tokenGenerator;
+        this.customUserDetailsService = customUserDetailsService;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,

--- a/src/main/java/com/pokemonreview/api/security/SecurityConfig.java
+++ b/src/main/java/com/pokemonreview/api/security/SecurityConfig.java
@@ -31,7 +31,12 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(
+            HttpSecurity http,
+            JwtAuthEntryPoint authEntryPoint,
+            JWTGenerator jwtGenerator,
+            CustomUserDetailsService userDetailsService
+    ) throws Exception {
         http
                 .csrf().disable()
                 .exceptionHandling()
@@ -45,7 +50,12 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
                 .and()
                 .httpBasic();
-        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(
+                jwtAuthenticationFilter(
+                        jwtGenerator,
+                        userDetailsService
+                ), UsernamePasswordAuthenticationFilter.class
+        );
         return http.build();
     }
 
@@ -61,7 +71,10 @@ public class SecurityConfig {
     }
 
     @Bean
-    public  JWTAuthenticationFilter jwtAuthenticationFilter() {
-        return new JWTAuthenticationFilter();
+    public JWTAuthenticationFilter jwtAuthenticationFilter(
+            JWTGenerator jwtGenerator,
+            CustomUserDetailsService userDetailsService
+    ) {
+        return new JWTAuthenticationFilter(jwtGenerator, userDetailsService);
     }
 }


### PR DESCRIPTION
Springboot is accountable of getting them because they are both `@Component`, letting `filterChain()` free to just use them.
After that I pass these two params manually to a second `@Bean` (`jwtAuthenticationFilter()`) when invoked in `http.AddFilterBefore()`, invoking `JwtAuthenticationFilter` constructor with needed params without forcing a non-natural `@Autowired` injection into the instance variables declarations in its class body.